### PR TITLE
Allow declaring `render` with a `Peer` argument

### DIFF
--- a/src/host/net.rs
+++ b/src/host/net.rs
@@ -9,16 +9,7 @@ type C<'a, 'b> = wasmi::Caller<'a, Box<State<'b>>>;
 pub(crate) fn get_me(mut caller: C) -> u32 {
     let state = caller.data_mut();
     state.called = "net.get_me";
-    let handler = state.net_handler.get_mut();
-    let NetHandler::FrameSyncer(syncer) = handler else {
-        return 0;
-    };
-    for (peer, i) in syncer.peers.iter().zip(0u32..) {
-        if peer.addr.is_none() {
-            return i;
-        }
-    }
-    unreachable!("list of peers has no local device")
+    state.get_me()
 }
 
 /// Get the map of peers that are currently online.

--- a/src/state.rs
+++ b/src/state.rs
@@ -280,6 +280,19 @@ impl<'a> State<'a> {
         }
     }
 
+    pub(crate) fn get_me(&mut self) -> u32 {
+        let handler = self.net_handler.get_mut();
+        let NetHandler::FrameSyncer(syncer) = handler else {
+            return 0;
+        };
+        for (peer, i) in syncer.peers.iter().zip(0u32..) {
+            if peer.addr.is_none() {
+                return i;
+            }
+        }
+        unreachable!("list of peers has no local device")
+    }
+
     /// Dump app stats on disk.
     pub(crate) fn save_app_stats(&mut self) {
         let Some(stats) = &self.app_stats else {


### PR DESCRIPTION
The `get_me` function is a footgun. If used in `update` it will cause desyncs in multiplayer. It's mainly meant to be used in `render` in order to render only the local player's view or in case all views are the same, possibly highlight the local player's character specially or sth.

What we can do instead is setup `render` to take a `Peer` argument that always points to the local player. In the future we can then (in no particular order or whether it should be done, just declaring it can be done):

* deprecate `get_me` in all sdks (or rename it to sth that marks it as a footgun)
* just make the function fail unconditionally if invoked from anyhwere but `render`
* rip it out entirely from the wasm API
* remove the ability to define `render` without `Peer` to simplify the API, runtime and general game author confusion

In theory the current system allows for there to be both a `render` function with an argument and one without, but practically that's not sth wasm allows, or at least none of the languages that compile to wasm.

There is a small cost in the runtime for checking which version of `render` is there and should be invoked, but it's just a single boolean check, so should not really be impactful, especially if the plan is to do a follow up and remove the ability to use `render` without an argument.